### PR TITLE
Check for clean notebooks

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -2,11 +2,18 @@ name: Build and deploy
 
 on:
   workflow_dispatch:
-  push:
+  workflow_run:
+    workflows:
+      - CI
+    types:
+      - completed
+    branches:
+      - main
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  workflow_dispatch:
+  push:
+
+jobs:
+  check-for-clean-notebooks:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Clean notebooks
+        run: |
+          docker run --volume $(pwd):/workspace ghcr.io/opensafely-core/python:latest jupyter nbconvert --ClearOutputPreprocessor.enabled=True --inplace notebooks/*.ipynb
+
+      - name: Check for clean notebooks
+        run: |
+          git diff --name-only --exit-code

--- a/notebooks/month_season.ipynb
+++ b/notebooks/month_season.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -14,7 +14,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -24,57 +24,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "0   2022-01-01\n",
-       "1   2022-01-02\n",
-       "2   2022-01-03\n",
-       "3   2022-01-04\n",
-       "4   2022-01-05\n",
-       "Name: date, dtype: datetime64[ns]"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "s.head()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "360   2022-12-27\n",
-       "361   2022-12-28\n",
-       "362   2022-12-29\n",
-       "363   2022-12-30\n",
-       "364   2022-12-31\n",
-       "Name: date, dtype: datetime64[ns]"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "s.tail()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -83,7 +51,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -107,38 +75,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{1: 'Winter',\n",
-       " 2: 'Winter',\n",
-       " 3: 'Spring',\n",
-       " 4: 'Spring',\n",
-       " 5: 'Spring',\n",
-       " 6: 'Summer',\n",
-       " 7: 'Summer',\n",
-       " 8: 'Summer',\n",
-       " 9: 'Autumn',\n",
-       " 10: 'Autumn',\n",
-       " 11: 'Autumn',\n",
-       " 12: 'Winter'}"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "month_season"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -154,7 +100,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -170,38 +116,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{3: 'Spring',\n",
-       " 4: 'Spring',\n",
-       " 5: 'Spring',\n",
-       " 6: 'Summer',\n",
-       " 7: 'Summer',\n",
-       " 8: 'Summer',\n",
-       " 9: 'Autumn',\n",
-       " 10: 'Autumn',\n",
-       " 11: 'Autumn',\n",
-       " 12: 'Winter',\n",
-       " 1: 'Winter',\n",
-       " 2: 'Winter'}"
-      ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "month_season"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -216,7 +140,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -225,7 +149,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -234,61 +158,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{1: 'Winter',\n",
-       " 2: 'Winter',\n",
-       " 3: 'Spring',\n",
-       " 4: 'Spring',\n",
-       " 5: 'Spring',\n",
-       " 6: 'Summer',\n",
-       " 7: 'Summer',\n",
-       " 8: 'Summer',\n",
-       " 9: 'Autumn',\n",
-       " 10: 'Autumn',\n",
-       " 11: 'Autumn',\n",
-       " 12: 'Winter'}"
-      ]
-     },
-     "execution_count": 14,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "month_season"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "34     Winter\n",
-       "273    Autumn\n",
-       "166    Summer\n",
-       "212    Summer\n",
-       "43     Winter\n",
-       "142    Spring\n",
-       "206    Summer\n",
-       "157    Summer\n",
-       "40     Winter\n",
-       "148    Spring\n",
-       "Name: date, dtype: object"
-      ]
-     },
-     "execution_count": 15,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# substitute month index for season name\n",
     "s.dt.month.map(month_season).sample(10)"


### PR DESCRIPTION
This PR adds a CI workflow that checks for _clean_ notebooks, or notebooks where all cells have `"execution_count": null` and `"outputs": []`. As this workflow is foundational, it makes the Build and deploy workflow dependent on it.